### PR TITLE
adding CFLAGS to work around deprecated-declarations.

### DIFF
--- a/type.go
+++ b/type.go
@@ -8,6 +8,7 @@ package glib
 #define _GINT_SIZE sizeof(gint)
 #define _GLONG_SIZE sizeof(glong)
 
+#cgo CFLAGS: -Wno-deprecated-declarations
 #cgo pkg-config: glib-2.0 gobject-2.0 gthread-2.0
 */
 import "C"


### PR DESCRIPTION
Versions:
- libglib2.0-dev 2.36.3-2
- gcc 4:4.8.1-1

Error: # github.com/ziutek/glib
type.go:19:1: error: 'g_type_init' is deprecated (declared at
/usr/include/glib-2.0/gobject/gtype.h:669)
[-Werror=deprecated-declarations]
 )
  ^
  cc1: all warnings being treated as errors
